### PR TITLE
Add REST API controllers with Swagger

### DIFF
--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -13,4 +13,51 @@
     <version>0.0.1-SNAPSHOT</version>
     <name>api-rest</name>
     <description>Executes the core logic from terminal calls</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>3.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.caremao.codebreaker</groupId>
+            <artifactId>code-cracker-core</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>3.5.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/api-rest/src/main/java/com/caremao/codebreaker/api/ApiRestApplication.java
+++ b/api-rest/src/main/java/com/caremao/codebreaker/api/ApiRestApplication.java
@@ -1,0 +1,12 @@
+package com.caremao.codebreaker.api;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ApiRestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ApiRestApplication.class, args);
+    }
+}

--- a/api-rest/src/main/java/com/caremao/codebreaker/api/controller/CodeBreakerController.java
+++ b/api-rest/src/main/java/com/caremao/codebreaker/api/controller/CodeBreakerController.java
@@ -1,0 +1,60 @@
+package com.caremao.codebreaker.api.controller;
+
+import com.caremao.codebreaker.api.model.SelectionRequest;
+import com.caremao.codebreaker.api.model.WordMatchResponse;
+import com.caremao.codebreaker.api.model.WordRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collections;
+import java.util.List;
+
+@RestController
+@RequestMapping("/codebreaker")
+public class CodeBreakerController {
+
+    @PostMapping("/words")
+    @Operation(summary = "Agrega una nueva palabra a la lista")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Palabra agregada"),
+            @ApiResponse(responseCode = "400", description = "Palabra no válida")
+    })
+    public ResponseEntity<Void> addWord(@RequestBody WordRequest request) {
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/select")
+    @Operation(summary = "Selecciona una palabra y envía el número de aciertos")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Lista filtrada"),
+            @ApiResponse(responseCode = "404", description = "Palabra no existe")
+    })
+    public ResponseEntity<List<WordMatchResponse>> selectWord(@RequestBody SelectionRequest request) {
+        return ResponseEntity.ok(Collections.emptyList());
+    }
+
+    @GetMapping("/words")
+    @Operation(summary = "Devuelve la lista ordenada de palabras con su número actual de coincidencias")
+    public ResponseEntity<List<WordMatchResponse>> listWords() {
+        return ResponseEntity.ok(Collections.emptyList());
+    }
+
+    @PostMapping("/reset")
+    @Operation(summary = "Reinicia el estado del juego")
+    public ResponseEntity<List<WordMatchResponse>> reset() {
+        return ResponseEntity.ok(Collections.emptyList());
+    }
+
+    @DeleteMapping("/words/{word}")
+    @Operation(summary = "Elimina una palabra específica de la lista")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Eliminado"),
+            @ApiResponse(responseCode = "404", description = "No existe")
+    })
+    public ResponseEntity<Void> deleteWord(@PathVariable String word) {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/api-rest/src/main/java/com/caremao/codebreaker/api/model/SelectionRequest.java
+++ b/api-rest/src/main/java/com/caremao/codebreaker/api/model/SelectionRequest.java
@@ -1,0 +1,3 @@
+package com.caremao.codebreaker.api.model;
+
+public record SelectionRequest(String word, int hits) {}

--- a/api-rest/src/main/java/com/caremao/codebreaker/api/model/WordMatchResponse.java
+++ b/api-rest/src/main/java/com/caremao/codebreaker/api/model/WordMatchResponse.java
@@ -1,0 +1,3 @@
+package com.caremao.codebreaker.api.model;
+
+public record WordMatchResponse(String word, int matches) {}

--- a/api-rest/src/main/java/com/caremao/codebreaker/api/model/WordRequest.java
+++ b/api-rest/src/main/java/com/caremao/codebreaker/api/model/WordRequest.java
@@ -1,0 +1,3 @@
+package com.caremao.codebreaker.api.model;
+
+public record WordRequest(String word) {}

--- a/api-rest/src/test/java/com/caremao/codebreaker/api/ApiRestApplicationTests.java
+++ b/api-rest/src/test/java/com/caremao/codebreaker/api/ApiRestApplicationTests.java
@@ -1,0 +1,12 @@
+package com.caremao.codebreaker.api;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApiRestApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- setup Spring Boot web project for api-rest module
- add dependencies including swagger support
- implement `ApiRestApplication` with `CodeBreakerController`
- create request/response model records
- add initial context load test

## Testing
- `./core/mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_687134b4ad30832987964a3a32f00896