### PR TITLE
Enable API server port configuration

### DIFF
--- a/api-rest/Dockerfile
+++ b/api-rest/Dockerfile
@@ -1,0 +1,18 @@
+# Use a minimal JVM image
+FROM eclipse-temurin:17-jre
+
+# Set working directory
+WORKDIR /app
+
+# Copy built jar from build stage or host
+ARG JAR_FILE=target/code-cracker-api-rest-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE} app.jar
+
+# Expose default port
+EXPOSE 8124
+
+# Allow port to be overridden with SERVER_PORT env variable
+ENV SERVER_PORT=8124
+
+# Run application
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/api-rest/src/main/resources/application.properties
+++ b/api-rest/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=${SERVER_PORT:8124}

--- a/web-cli/src/hooks/useCodebreaker.ts
+++ b/web-cli/src/hooks/useCodebreaker.ts
@@ -2,7 +2,7 @@
 import { useState, useCallback } from 'react';
 import { Word } from '@/types/codebreaker';
 
-const API_BASE = 'http://localhost/codebreaker/v1';
+const API_BASE = 'http://localhost:8124/codebreaker/v1';
 
 export const useCodebreaker = () => {
   const [words, setWords] = useState<Word[]>([]);


### PR DESCRIPTION
## Summary
- configure Spring Boot server port with default 8124
- provide Dockerfile for api-rest module
- update web frontend to call API on new port

## Testing
- `mvn -q -DskipTests=false test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68718da97d5c8329b4079449f44c60bf