### PR TITLE
Add Docker support for api-rest and web-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Code Cracker Docker Setup
+
+This project provides Docker images for the API (`api-rest`) and the web client (`web-cli`). The easiest way to run them together is with Docker Compose.
+
+## Build and run using Docker Compose
+
+1. Ensure Docker and Docker Compose are installed.
+2. From the project root, build the images:
+   ```bash
+   docker compose build
+   ```
+3. Start the containers:
+   ```bash
+   docker compose up
+   ```
+4. Access the services:
+   - API: `http://localhost:8124/codebreaker/v1`
+   - Web client: `http://localhost:8080`
+
+Stop the containers with `Ctrl+C` and remove them with `docker compose down`.
+
+## Configuration
+
+- `api-rest` exposes port **8124** and reads `SERVER_PORT` from the environment.
+- `web-cli` is built with the `VITE_API_BASE` build argument. In `docker-compose.yml` it is set to communicate with the `api-rest` container.
+

--- a/api-rest/Dockerfile
+++ b/api-rest/Dockerfile
@@ -1,18 +1,22 @@
-# Use a minimal JVM image
+# Build the Spring Boot application
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+# copy pom files first for layer caching
+COPY pom.xml ./
+COPY core/pom.xml core/pom.xml
+COPY api-rest/pom.xml api-rest/pom.xml
+
+# copy sources
+COPY core/src core/src
+COPY api-rest/src api-rest/src
+
+RUN mvn -pl api-rest -am package -DskipTests
+
+# Runtime image
 FROM eclipse-temurin:17-jre
-
-# Set working directory
 WORKDIR /app
-
-# Copy built jar from build stage or host
-ARG JAR_FILE=target/code-cracker-api-rest-0.0.1-SNAPSHOT.jar
-COPY ${JAR_FILE} app.jar
-
-# Expose default port
+COPY --from=build /workspace/api-rest/target/code-cracker-api-rest-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8124
-
-# Allow port to be overridden with SERVER_PORT env variable
 ENV SERVER_PORT=8124
-
-# Run application
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+services:
+  api-rest:
+    build: ./api-rest
+    ports:
+      - "8124:8124"
+    environment:
+      - SERVER_PORT=8124
+
+  web-cli:
+    build:
+      context: ./web-cli
+      args:
+        VITE_API_BASE: http://api-rest:8124/codebreaker/v1
+    ports:
+      - "8080:80"
+    depends_on:
+      - api-rest

--- a/web-cli/Dockerfile
+++ b/web-cli/Dockerfile
@@ -1,0 +1,18 @@
+# Build the React app
+FROM node:20 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+
+# allow API endpoint to be set during build
+ARG VITE_API_BASE=http://localhost:8124/codebreaker/v1
+ENV VITE_API_BASE=$VITE_API_BASE
+
+RUN npm run build
+
+# Serve the static files with nginx
+FROM nginx:1.27-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/web-cli/src/hooks/useCodebreaker.ts
+++ b/web-cli/src/hooks/useCodebreaker.ts
@@ -2,7 +2,9 @@
 import { useState, useCallback } from 'react';
 import { Word } from '@/types/codebreaker';
 
-const API_BASE = 'http://localhost:8124/codebreaker/v1';
+// allow the api base url to be configured at build time
+const API_BASE =
+  import.meta.env.VITE_API_BASE ?? 'http://localhost:8124/codebreaker/v1';
 
 export const useCodebreaker = () => {
   const [words, setWords] = useState<Word[]>([]);


### PR DESCRIPTION
## Summary
- enable runtime configuration of API endpoint for web cli
- add Dockerfile for web client
- update api-rest Dockerfile to build project inside container
- add docker-compose.yml to run api-rest and web-cli together
- document container usage

## Testing
- `npm install`
- `npm run build` in `web-cli`
- `./core/mvnw -f pom.xml -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687195f86d448329a41944c634ea7c00