### PR TITLE
Fix Docker context for API build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: "3.9"
 services:
   api-rest:
-    build: ./api-rest
+    build:
+      context: .
+      dockerfile: api-rest/Dockerfile
     ports:
       - "8124:8124"
     environment:


### PR DESCRIPTION
## Summary
- fix `docker-compose.yml` so that the API can copy from other modules during image build

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6872ca42511c8329874d7c6072b7fd7e