### PR TITLE
Fix missing CLI module in Docker build

### DIFF
--- a/api-rest/Dockerfile
+++ b/api-rest/Dockerfile
@@ -5,10 +5,12 @@ WORKDIR /workspace
 # copy pom files first for layer caching
 COPY pom.xml ./
 COPY core/pom.xml core/pom.xml
+COPY cli/pom.xml cli/pom.xml
 COPY api-rest/pom.xml api-rest/pom.xml
 
 # copy sources
 COPY core/src core/src
+COPY cli/src cli/src
 COPY api-rest/src api-rest/src
 
 RUN mvn -pl api-rest -am package -DskipTests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: "3.9"
 services:
   api-rest:
-    build: ./api-rest
+    build:
+      context: .
+      dockerfile: api-rest/Dockerfile
     ports:
       - "8124:8124"
     environment:


### PR DESCRIPTION
## Summary
- include CLI module in the API Docker build to satisfy Maven module checks

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6872ca42511c8329874d7c6072b7fd7e