### PR TITLE
Fix default API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,7 @@ Stop the containers with `Ctrl+C` and remove them with `docker compose down`.
 ## Configuration
 
 - `api-rest` exposes port **8124** and reads `SERVER_PORT` from the environment.
-- `web-cli` is built with the `VITE_API_BASE` build argument. In `docker-compose.yml` it is set to communicate with the `api-rest` container.
+- `web-cli` is built with the `VITE_API_BASE` build argument. By default it points
+  to `http://192.168.100.142:8124/codebreaker/v1` but can be overridden during
+  the build.
 

--- a/web-cli/src/hooks/useCodebreaker.ts
+++ b/web-cli/src/hooks/useCodebreaker.ts
@@ -3,8 +3,9 @@ import { useState, useCallback } from 'react';
 import { Word } from '@/types/codebreaker';
 
 // allow the api base url to be configured at build time
+// default to the network IP when no build-time variable is provided
 const API_BASE =
-  import.meta.env.VITE_API_BASE ?? 'http://localhost:8124/codebreaker/v1';
+  import.meta.env.VITE_API_BASE ?? 'http://192.168.100.142:8124/codebreaker/v1';
 
 export const useCodebreaker = () => {
   const [words, setWords] = useState<Word[]>([]);


### PR DESCRIPTION
## Summary
- set the default API base URL for the web client to the host IP
- document the default API base URL in README

## Testing
- `npm ci` (web-cli)
- `VITE_API_BASE=http://192.168.100.142:8124/codebreaker/v1 npm run build` (web-cli)
- `mvn -q test` *(fails: Plugin resolution failed – network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687539cac84c8329869a00b5173d465e