### PR TITLE
Make web client API endpoint configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# API endpoint used by the web client
+API_ENDPOINT=http://192.168.100.142:8124/codebreaker/v1

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project provides Docker images for the API (`api-rest`) and the web client 
    docker compose up
    ```
 4. Access the services:
-   - API: `http://localhost:8124/codebreaker/v1`
+   - API: `http://192.168.100.142:8124/codebreaker/v1`
    - Web client: `http://localhost:8080`
 
 Stop the containers with `Ctrl+C` and remove them with `docker compose down`.
@@ -22,7 +22,6 @@ Stop the containers with `Ctrl+C` and remove them with `docker compose down`.
 ## Configuration
 
 - `api-rest` exposes port **8124** and reads `SERVER_PORT` from the environment.
-- `web-cli` is built with the `VITE_API_BASE` build argument. By default it points
-  to `http://192.168.100.142:8124/codebreaker/v1` but can be overridden during
-  the build.
+- `web-cli` reads the API endpoint from the `API_ENDPOINT` environment variable.
+  If not set it defaults to `http://192.168.100.142:8124/codebreaker/v1`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,8 @@ services:
     build:
       context: ./web-cli
       args:
-        VITE_API_BASE: http://192.168.100.142:8124/codebreaker/v1
+        # pass the API endpoint via environment variable for flexible configuration
+        VITE_API_BASE: ${API_ENDPOINT:-http://192.168.100.142:8124/codebreaker/v1}
     ports:
       - "8080:80"
     depends_on:

--- a/web-cli/Dockerfile
+++ b/web-cli/Dockerfile
@@ -6,7 +6,7 @@ RUN npm ci
 COPY . .
 
 # allow API endpoint to be set during build
-ARG VITE_API_BASE=http://localhost:8124/codebreaker/v1
+ARG VITE_API_BASE=http://192.168.100.142:8124/codebreaker/v1
 ENV VITE_API_BASE=$VITE_API_BASE
 
 RUN npm run build

--- a/web-cli/src/hooks/useCodebreaker.ts
+++ b/web-cli/src/hooks/useCodebreaker.ts
@@ -2,10 +2,10 @@
 import { useState, useCallback } from 'react';
 import { Word } from '@/types/codebreaker';
 
-// allow the api base url to be configured at build time
-// default to the network IP when no build-time variable is provided
+// allow the API base URL to be configured at build time
+// default to the network IP when not provided
 const API_BASE =
-  import.meta.env.VITE_API_BASE ?? 'http://192.168.100.142:8124/codebreaker/v1';
+  import.meta.env.VITE_API_BASE || 'http://192.168.100.142:8124/codebreaker/v1';
 
 export const useCodebreaker = () => {
   const [words, setWords] = useState<Word[]>([]);


### PR DESCRIPTION
## Summary
- use `API_ENDPOINT` variable for `VITE_API_BASE` in docker-compose
- default API base is now `http://192.168.100.142:8124/codebreaker/v1`
- document default endpoint and example env file
- update hook and Dockerfile to match the default

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6875731a36f88329b09b404c4fba1eec